### PR TITLE
fix poster ref; add missing requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,6 @@ Documentation can be found at `<https://daler.github.io/hubward>`_.
 Overview
 --------
 `This poster
-<https://github.com/daler/hubward/raw/master/docs/images/hubward-poster.pdf>`_ gives an overview of `hubward`, and provides a worked example.
+<https://github.com/daler/hubward/raw/master/docs/images/hubward-poster.pdf>`__ gives an overview of `hubward`, and provides a worked example.
 
 Further details can be found in the `full documentation <https://daler.github.io/hubward>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ fabric
 trackhub
 docutils
 wget
+functools32


### PR DESCRIPTION
I haven't been able to test the docs build, note, but I think this fixes the link on http://daler.github.io/hubward/ to the poster.
